### PR TITLE
makes comparator safer.

### DIFF
--- a/lib/observe.js
+++ b/lib/observe.js
@@ -32,7 +32,7 @@ var Observer = function(query, queryOptions, collection, options) {
 
 Observer.prototype.refresh = function(initial) {
 	var self = this;
-	
+
 	this._collection._getDocuments(this._query, function(err, result) {
 		if(initial && self._options.init) {
 			self._cache = result;
@@ -42,7 +42,7 @@ Observer.prototype.refresh = function(initial) {
 
       self._cache = merge(old, result, _.defaults({
         comparatorId: function (a, b) {
-          return a._id === b._id
+					return _.get(a, '_id') === _.get(b, '_id')
         }
       }, self._options));
       //rewind cursor for next query...

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewdb",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Will stop throwing on cases where result is not part of cache due to for instance removal of documents in queries with limit. (result will have document, but cache will not)