### PR TITLE
Add support for updateOne & updateMany

### DIFF
--- a/lib/plugins/viewdb_timestamp_plugin.js
+++ b/lib/plugins/viewdb_timestamp_plugin.js
@@ -60,6 +60,44 @@ var ViewDBTimestampPlugin = function (viewDb) {
         clonedUpdate.$set = set;
         oldFindAndModify.apply(this, [query, sort, clonedUpdate, options, cb]);
       };
+
+      var oldUpdateMany = coll.updateMany;
+      coll.updateMany = function (query, update, options, cb) {
+        var timestamp = new Date().valueOf();
+        var clonedUpdate = _.clone(update);
+        var setOnInsert = clonedUpdate.$setOnInsert || {};
+        setOnInsert.createDateTime = timestamp;
+        clonedUpdate.$setOnInsert = setOnInsert;
+
+        var set = clonedUpdate.$set || {};
+        set.changeDateTime = timestamp;
+
+        // if consumer tries to $set createDateTime it will lead to conflict. remove it
+        if (set.createDateTime) {
+          delete set.createDateTime;
+        }
+        clonedUpdate.$set = set;
+        oldUpdateMany.apply(this, [query, clonedUpdate, options, cb]);
+      };
+
+      var oldUpdateOne = coll.updateOne;
+      coll.updateOne = function (query, update, options, cb) {
+        var timestamp = new Date().valueOf();
+        var clonedUpdate = _.clone(update);
+        var setOnInsert = clonedUpdate.$setOnInsert || {};
+        setOnInsert.createDateTime = timestamp;
+        clonedUpdate.$setOnInsert = setOnInsert;
+
+        var set = clonedUpdate.$set || {};
+        set.changeDateTime = timestamp;
+
+        // if consumer tries to $set createDateTime it will lead to conflict. remove it
+        if (set.createDateTime) {
+          delete set.createDateTime;
+        }
+        clonedUpdate.$set = set;
+        oldUpdateOne.apply(this, [query, clonedUpdate, options, cb]);
+      };
     }
     return coll;
   };

--- a/lib/plugins/viewdb_versioning_plugin.js
+++ b/lib/plugins/viewdb_versioning_plugin.js
@@ -48,6 +48,32 @@ var ViewDBVersioningPlugin = function (viewDb) {
         }
         oldFindAndModify.apply(this, arguments);
       };
+
+      var oldUpdateMany = coll.updateMany;
+      coll.updateMany = function (query, update, options, cb) {
+        if (!(options && options.skipVersioning)) {
+          var inc = update.$inc || {};
+          inc.version = 1;
+          update.$inc = inc;
+          if (update.$set && update.$set.version >= 0) {
+            delete update.$set.version;
+          }
+        }
+        oldUpdateMany.apply(this, arguments);
+      };
+
+      var oldUpdateOne = coll.updateOne;
+      coll.updateOne = function (query, update, options, cb) {
+        if (!(options && options.skipVersioning)) {
+          var inc = update.$inc || {};
+          inc.version = 1;
+          update.$inc = inc;
+          if (update.$set && update.$set.version >= 0) {
+            delete update.$set.version;
+          }
+        }
+        oldUpdateOne.apply(this, arguments);
+      };
     }
     return coll;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewdb",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Makes it so that the timestamp and versioning plugins support viewdb stores using `updateOne` or `updateMany`.