### PR TITLE
Fix: Fixed issue query on observer

### DIFF
--- a/lib/observe.js
+++ b/lib/observe.js
@@ -25,8 +25,8 @@ var Observer = function (query, queryOptions, collection, options) {
 
 Observer.prototype.refresh = function (initial) {
   var self = this;
-
-  this._collection._getDocuments(this._query, function (err, result) {
+  const mergedQuery = _.merge(this._query, this._queryOptions);
+  this._collection._getDocuments(mergedQuery, function (err, result) {
     if (initial && self._options.init) {
       self._cache = result;
       self._options.init(result);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viewdb",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "viewdb",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "kuery": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewdb",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "",
   "main": "index.js",
   "directories": {

--- a/test/observe.js
+++ b/test/observe.js
@@ -162,4 +162,26 @@ describe('Observe', () => {
       );
     });
   });
+  it('#observe with query and sort', (done) => {
+    var store = new ViewDb();
+    store.open().then(function () {
+      store.collection('dollhouse').insert({ _id: 'echo', age: 10 });
+      store.collection('dollhouse').insert({ _id: 'echo2', age: 20 });
+      store.collection('dollhouse').insert({ _id: 'echo3', age: 30 });
+      var cursor = store.collection('dollhouse').find({});
+      cursor.sort({ age: -1 });
+      var realDone = _.after(3, function () {
+        cursor.toArray(function (err, res) {
+          expect(res[0].age).toBe(30);
+          handle.stop();
+          done();
+        });
+      });
+      var handle = cursor.observe({
+        added: function () {
+          realDone();
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Issue in question
When using `viewdb_persistence_store_mongodb` without oplogListener we use Legacy (viewdb observer) this causes issue since mongodb cursor sets is options like: limit, sort and skip in `queryOptions` which gets never used on our observer. Since our cursor in viewdb we set everything in the `query` parameters not `queryOptions`.

This gets fixed when we merge both `query` and `queryOptions` into one object.