### PR TITLE
refactor: replace structural any types with domain interfaces (Tier 2)

### DIFF
--- a/packages/viewdb/src/cursor.ts
+++ b/packages/viewdb/src/cursor.ts
@@ -1,17 +1,15 @@
 import _ = require('lodash');
 import Observer = require('./observe');
-import { QueryObject, SortSpec, Callback, VDocument } from './types';
-
-type GetDocumentsFn = (queryObject: QueryObject, callback: Callback<VDocument[]>) => void;
+import { QueryObject, SortSpec, Callback, VDocument, ObserveOptions, ObserveHandle, CollectionLike, GetDocumentsFn } from './types';
 
 class Cursor {
-  _collection: any;
+  _collection: CollectionLike;
   _query: QueryObject;
   _options: QueryObject;
   _getDocuments: GetDocumentsFn;
   _isObserving: boolean;
 
-  constructor(collection: any, query: QueryObject, options: QueryObject, getDocuments: GetDocumentsFn) {
+  constructor(collection: CollectionLike, query: QueryObject, options: QueryObject, getDocuments: GetDocumentsFn) {
     this._collection = collection;
     this._query = query;
     this._options = options;
@@ -31,7 +29,7 @@ class Cursor {
     this._getDocuments(this._query, callback);
   }
 
-  observe(options: any): { stop(): void } {
+  observe(options: ObserveOptions): ObserveHandle {
     this._isObserving = true;
     // Observer constructor returns { stop } object, not the Observer instance
     return new Observer(this._query, this._options, this._collection, options) as any;

--- a/packages/viewdb/src/inmemory/collection.ts
+++ b/packages/viewdb/src/inmemory/collection.ts
@@ -3,9 +3,9 @@ import { v4 as uuid } from 'uuid';
 import { EventEmitter } from 'events';
 import Kuery = require('kuery');
 import Cursor = require('../cursor');
-import { VDocument, QueryObject, Callback } from '../types';
+import { VDocument, QueryObject, Callback, CollectionLike } from '../types';
 
-class Collection extends EventEmitter {
+class Collection extends EventEmitter implements CollectionLike {
   _documents: VDocument[];
   _name: string;
 

--- a/packages/viewdb/src/observe.ts
+++ b/packages/viewdb/src/observe.ts
@@ -1,15 +1,15 @@
 import _ = require('lodash');
 import merge = require('./merger');
-import { QueryObject, VDocument } from './types';
+import { QueryObject, VDocument, ObserveOptions, CollectionLike } from './types';
 
 class Observer {
   _query: QueryObject;
   _queryOptions: QueryObject;
-  _options: any;
-  _collection: any;
+  _options: ObserveOptions;
+  _collection: CollectionLike;
   _cache: VDocument[] | null;
 
-  constructor(query: QueryObject, queryOptions: QueryObject, collection: any, options: any) {
+  constructor(query: QueryObject, queryOptions: QueryObject, collection: CollectionLike, options: ObserveOptions) {
     this._query = query;
     this._queryOptions = queryOptions;
     this._options = options;
@@ -38,7 +38,7 @@ class Observer {
     this._collection._getDocuments(this._query, function (err: Error | null, result?: VDocument[]) {
       if (initial && self._options.init) {
         self._cache = result!;
-        self._options.init(result);
+        self._options.init(result!);
       } else {
         const old = self._cache;
         self._cache = merge(

--- a/packages/viewdb/src/types.ts
+++ b/packages/viewdb/src/types.ts
@@ -28,3 +28,36 @@ export interface MergeOptions<T = any> {
   changed?: (oldElement: T, newElement: T, index: number) => void;
   moved?: (element: T, fromIndex: number, toIndex: number) => void;
 }
+
+/** Options passed to cursor.observe() */
+export interface ObserveOptions<T = VDocument> {
+  init?: (elements: T[]) => void;
+  added?: (element: T, index: number) => void;
+  removed?: (element: T, index: number) => void;
+  changed?: (asis: T, tobe: T, index: number) => void;
+  moved?: (element: T, fromIndex: number, toIndex: number) => void;
+}
+
+/** Handle returned by observe() */
+export interface ObserveHandle {
+  stop: () => void | Promise<void>;
+  dispose?: () => void | Promise<void>;
+}
+
+/**
+ * Callback signature for _getDocuments implementations.
+ * Used by Collection implementations across all stores.
+ */
+export type GetDocumentsFn = (queryObject: QueryObject, callback: Callback<VDocument[]>) => void;
+
+/**
+ * Abstract collection interface that all store collections should satisfy.
+ * Used internally to type _collection fields in cursor/observe.
+ */
+export interface CollectionLike {
+  find(query: Record<string, any>, options?: Record<string, any>): any;
+  _getDocuments: GetDocumentsFn;
+  emit(event: string, ...args: any[]): void;
+  on(event: string, listener: (...args: any[]) => void): any;
+  removeListener(event: string, listener: (...args: any[]) => void): any;
+}

--- a/packages/viewdb/src/viewdb.ts
+++ b/packages/viewdb/src/viewdb.ts
@@ -1,9 +1,9 @@
 import InMemoryStore = require('./inmemory/store');
-import { Callback } from './types';
+import { Callback, CollectionLike } from './types';
 
 interface ViewDBStore {
   open?(callback?: Callback<any>): Promise<any>;
-  collection(name: string, callback?: (coll: any) => void): any;
+  collection(name: string, callback?: (coll: CollectionLike) => void): CollectionLike;
 }
 
 class ViewDB {
@@ -23,7 +23,7 @@ class ViewDB {
     }
   }
 
-  collection(collectionName: string, callback?: (collection: any) => void): any {
+  collection(collectionName: string, callback?: (collection: CollectionLike) => void): CollectionLike {
     return this._store.collection(collectionName, callback);
   }
 }

--- a/packages/viewdb_persistence_store_indexeddb/src/collection.ts
+++ b/packages/viewdb_persistence_store_indexeddb/src/collection.ts
@@ -9,10 +9,10 @@ var Cursor = ViewDB.Cursor;
 
 class Collection extends EventEmitter {
   static Cursor: any = Cursor;
-  _db: any;
+  _db: IDBDatabase;
   _name: string;
 
-  constructor(db: any, name: string) {
+  constructor(db: IDBDatabase, name: string) {
     super();
     this._db = db;
     this._name = name;
@@ -55,18 +55,18 @@ class Collection extends EventEmitter {
     }
 
     return new Promise(function (resolve, reject) {
-      var txn = self._db.transaction(['documents'], 'readwrite');
-      var docs = txn.objectStore('documents');
+      var txn: IDBTransaction = self._db.transaction(['documents'], 'readwrite');
+      var docs: IDBObjectStore = txn.objectStore('documents');
 
-      txn.oncomplete = txn.onsuccess = function () {
+      txn.oncomplete = (txn as any).onsuccess = function () {
         self.emit('change', documents);
         process.nextTick(function () {
           resolve(documents);
         });
       };
 
-      txn.onerror = function (event: any) {
-        reject(new Error(event));
+      txn.onerror = function (event: Event) {
+        reject(new Error(String(event)));
       };
       var currentIndex = 0;
       var numberOfDocs = documents.length;
@@ -77,14 +77,14 @@ class Collection extends EventEmitter {
         }
         document.$collection = self._name;
         document.$collectionKey = self._getKey(document);
-        var request = docs[op](document);
+        var request: IDBRequest = (docs as any)[op](document);
         request.onsuccess = function () {
           if (currentIndex < numberOfDocs) {
             addNext();
           }
         };
-        request.onerror = function (event: any) {
-          reject(new Error(event));
+        request.onerror = function (event: Event) {
+          reject(new Error(String(event)));
         };
       }
       addNext();
@@ -99,15 +99,15 @@ class Collection extends EventEmitter {
     var txn = this._db.transaction(['documents'], 'readwrite');
     var docs = txn.objectStore('documents');
     var cursor = docs.index('$collection').openCursor(this._name);
-    cursor.onerror = function (event: any) {
+    cursor.onerror = function (event: Event) {
       if (callback) {
-        callback(new Error(event));
+        callback(new Error(String(event)));
       } else {
         console.log(event);
       }
     };
-    cursor.onsuccess = function (event: any) {
-      var c = event.target.result;
+    cursor.onsuccess = function (event: Event) {
+      var c = (event.target as IDBRequest<IDBCursorWithValue | null>).result;
       if (c) {
         c.delete();
         c.continue();
@@ -134,13 +134,13 @@ class Collection extends EventEmitter {
         callback(err);
       } else {
         var txn = self._db.transaction(['documents'], 'readwrite');
-        txn.oncomplete = txn.onsuccess = function () {
+        txn.oncomplete = (txn as any).onsuccess = function () {
           self.emit('change', { remove: query });
           callback(null);
         };
 
-        txn.onerror = function (event: any) {
-          callback(new Error(event));
+        txn.onerror = function (event: Event) {
+          callback(new Error(String(event)));
         };
         var docs = txn.objectStore('documents');
         _.forEach(res, function (doc: any) {
@@ -157,11 +157,11 @@ class Collection extends EventEmitter {
     var docs = txn.objectStore('documents');
     var cursor = docs.index('$collection').openCursor(this._name);
     var result: any[] = [];
-    cursor.onerror = function (event: any) {
-      callback(new Error(event));
+    cursor.onerror = function (event: Event) {
+      callback(new Error(String(event)));
     };
-    cursor.onsuccess = function (event: any) {
-      var c = event.target.result;
+    cursor.onsuccess = function (event: Event) {
+      var c = (event.target as IDBRequest<IDBCursorWithValue | null>).result;
       if (c) {
         result.push(c.value);
         c.continue();

--- a/packages/viewdb_persistence_store_indexeddb/src/store.ts
+++ b/packages/viewdb_persistence_store_indexeddb/src/store.ts
@@ -2,44 +2,44 @@ import Promise = require('bluebird');
 import Collection = require('./collection');
 
 class Store {
-  _idb: any;
-  _db: any;
+  _idb: IDBFactory;
+  _db: IDBDatabase | null;
   _name: string;
   _collections: Record<string, Collection>;
 
-  constructor(idb: any, name?: string) {
+  constructor(idb: IDBFactory, name?: string) {
     this._idb = idb;
-    this._db = undefined;
+    this._db = null;
     this._name = name ? 'vdb_' + name : 'vdb';
     this._collections = {};
   }
 
   open(callback?: (err: Error | null, value?: Store) => void): Promise<Store> {
     var self = this;
-    var request = this._idb.open(this._name, 2);
+    var request: IDBOpenDBRequest = this._idb.open(this._name, 2);
     return new Promise<Store>(function (resolve, reject) {
-      request.onsuccess = function (event: any) {
-        self._db = event.target.result;
+      request.onsuccess = function (event: Event) {
+        self._db = (event.target as IDBOpenDBRequest).result;
         resolve(self);
       };
-      request.onupgradeneeded = function (event: any) {
-        var db = event.target.result;
+      request.onupgradeneeded = function (event: IDBVersionChangeEvent) {
+        var db: IDBDatabase = (event.target as IDBOpenDBRequest).result;
         if (event.oldVersion < 1) {
-          var documents = db.createObjectStore('documents', { keyPath: '$collectionKey', unique: true });
+          var documents = db.createObjectStore('documents', { keyPath: '$collectionKey' });
           documents.createIndex('$collection', '$collection', { unique: false });
         }
         //fix for _id being keypath...
         if (event.oldVersion < 2) {
           db.deleteObjectStore('documents');
-          var documents = db.createObjectStore('documents', { keyPath: '$collectionKey', unique: true });
+          var documents = db.createObjectStore('documents', { keyPath: '$collectionKey' });
           documents.createIndex('$collection', '$collection', { unique: false });
         }
       };
-      request.onerror = function (event: any) {
-        reject(new Error(event));
+      request.onerror = function (event: Event) {
+        reject(new Error(String(event)));
       };
-      request.onblocked = function (event: any) {
-        reject(new Error(event));
+      request.onblocked = function (event: Event) {
+        reject(new Error(String(event)));
       };
     }).nodeify(callback);
   }
@@ -47,7 +47,7 @@ class Store {
   close(callback?: (err: Error | null) => void): Promise<void> {
     var self = this;
     return new Promise<void>(function (resolve, _reject) {
-      var req = self._db.close();
+      self._db!.close();
       resolve();
     }).nodeify(callback);
   }
@@ -55,7 +55,7 @@ class Store {
   delete(callback?: (err: Error | null) => void): Promise<void> {
     var self = this;
     return new Promise<void>(function (resolve, reject) {
-      var req = self._idb.deleteDatabase(self._name);
+      var req: IDBOpenDBRequest = self._idb.deleteDatabase(self._name);
       req.onsuccess = function () {
         resolve();
       };
@@ -68,7 +68,7 @@ class Store {
   collection(name: string, callback?: (collection: Collection) => void): Collection {
     var collection = this._collections[name];
     if (!collection) {
-      collection = this._collections[name] = new Collection(this._db, name);
+      collection = this._collections[name] = new Collection(this._db!, name);
     }
     if (callback) {
       callback(collection);

--- a/packages/viewdb_persistence_store_indexeddb/tsconfig.json
+++ b/packages/viewdb_persistence_store_indexeddb/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES5",
+    "lib": ["ES2018", "DOM"],
     "outDir": "dist",
     "rootDir": "src",
     "composite": true,

--- a/packages/viewdb_persistence_store_mongodb/src/collection.ts
+++ b/packages/viewdb_persistence_store_mongodb/src/collection.ts
@@ -2,23 +2,24 @@ import { EventEmitter } from 'events';
 import { forEach, isFunction, isArray } from 'lodash';
 import Cursor = require('./cursor');
 import { nodeify } from './utils';
+import type { Collection as MongoCollection, Document as MongoDocument } from 'mongodb';
 
 class Collection extends EventEmitter {
-  _collection: any;
+  _collection: MongoCollection<MongoDocument>;
   _oplogListener: any;
 
-  constructor(collection: any, oplogListener?: any) {
+  constructor(collection: MongoCollection<MongoDocument>, oplogListener?: any) {
     super();
     this._collection = collection;
     this._oplogListener = oplogListener;
   }
 
   count(): any {
-    return this._collection.count.apply(this._collection, arguments);
+    return (this._collection as any).count.apply(this._collection, arguments);
   }
 
   find(query: any, options?: any): Cursor {
-    var cursor = this._collection.find.apply(this._collection, arguments);
+    var cursor = (this._collection as any).find.apply(this._collection, arguments);
     return new Cursor(this, { query: query }, options, cursor, this._oplogListener);
   }
 
@@ -197,13 +198,14 @@ class Collection extends EventEmitter {
     if (queryObject.project) {
       cursor.project(queryObject.project);
     }
-    cursor.toArray().then(function (res: any, err: any) {
-      if (err) {
-        callback(err);
-      } else {
+    cursor
+      .toArray()
+      .then(function (res) {
         callback(null, res);
-      }
-    });
+      })
+      .catch(function (err: Error) {
+        callback(err);
+      });
   }
 }
 

--- a/packages/viewdb_persistence_store_mongodb/src/cursor.ts
+++ b/packages/viewdb_persistence_store_mongodb/src/cursor.ts
@@ -1,14 +1,15 @@
 import Observer = require('./observe');
 import { nodeify } from './utils';
+import type { FindCursor, Document as MongoDocument } from 'mongodb';
 
 class Cursor {
   _query: any;
   _queryOptions: { query?: any; skip?: number; limit?: number; sort?: Record<string, 1 | -1>; project?: Record<string, 0 | 1> };
-  _cursor: any;
+  _cursor: FindCursor<MongoDocument>;
   _oplogListener: any;
   _collection: any;
 
-  constructor(collection: any, query: any, options: any, cursor: any, oplogListener?: any) {
+  constructor(collection: any, query: any, options: any, cursor: FindCursor<MongoDocument>, oplogListener?: any) {
     this._query = query;
     this._queryOptions = options || {};
     this._cursor = cursor;
@@ -17,26 +18,26 @@ class Cursor {
   }
 
   each(): any {
-    return this._cursor.each.apply(this._cursor, arguments);
+    return (this._cursor as any).each.apply(this._cursor, arguments);
   }
 
   setReadPreference(): this {
-    this._cursor.withReadPreference.apply(this._cursor, arguments);
+    (this._cursor as any).withReadPreference.apply(this._cursor, arguments);
     return this;
   }
 
   count(callback?: (err: Error | null, count?: number) => void): any {
-    return nodeify(this._cursor.count.apply(this._cursor, arguments), callback);
+    return nodeify((this._cursor as any).count.apply(this._cursor, arguments), callback);
   }
 
   project(project: Record<string, 0 | 1>): this {
-    this._cursor.project.apply(this._cursor, arguments);
+    (this._cursor as any).project.apply(this._cursor, arguments);
     this._queryOptions.project = project;
     return this;
   }
 
   toArray(callback?: (err: Error | null, result?: any[]) => void): any {
-    return nodeify(this._cursor.toArray.apply(this._cursor, arguments), callback);
+    return nodeify((this._cursor as any).toArray.apply(this._cursor, arguments), callback);
   }
 
   observe(options: any): any {
@@ -44,7 +45,7 @@ class Cursor {
   }
 
   skip(skip: number): this {
-    this._cursor.skip.apply(this._cursor, arguments);
+    (this._cursor as any).skip.apply(this._cursor, arguments);
     this._queryOptions.skip = skip;
     this._refresh();
     return this;
@@ -52,14 +53,14 @@ class Cursor {
 
   limit(limit: number): this {
     this._queryOptions.limit = limit;
-    this._cursor.limit.apply(this._cursor, arguments);
+    (this._cursor as any).limit.apply(this._cursor, arguments);
     this._refresh();
     return this;
   }
 
   sort(sort: Record<string, 1 | -1>): this {
     this._queryOptions.sort = sort;
-    this._cursor.sort.apply(this._cursor, arguments);
+    (this._cursor as any).sort.apply(this._cursor, arguments);
     this._refresh();
     return this;
   }
@@ -69,11 +70,11 @@ class Cursor {
   }
 
   rewind(): any {
-    return this._cursor.rewind.apply(this._cursor, arguments);
+    return (this._cursor as any).rewind.apply(this._cursor, arguments);
   }
 
   close(callback?: (err: Error | null) => void): any {
-    return nodeify(this._cursor.close.apply(this._cursor, arguments), callback);
+    return nodeify((this._cursor as any).close.apply(this._cursor, arguments), callback);
   }
 }
 

--- a/packages/viewdb_persistence_store_mongodb/src/observe.ts
+++ b/packages/viewdb_persistence_store_mongodb/src/observe.ts
@@ -2,6 +2,7 @@ import _ = require('lodash');
 import Kuery = require('kuery');
 import { projectDocument } from './utils';
 import { LoggerFactory } from 'slf';
+import type { ObserveOptions, ObserveHandle } from 'viewdb/dist/types';
 
 var ViewDB = require('viewdb');
 var merge = ViewDB.merge;
@@ -12,7 +13,7 @@ const log = LoggerFactory.getLogger('viewdb_persistence_store_mongodb:observer')
 class Observer {
   _queryOptions!: { query?: any; skip?: number; limit?: number; sort?: Record<string, 1 | -1>; project?: Record<string, 0 | 1> };
   _query: any;
-  _options: any;
+  _options!: ObserveOptions;
   _collection: any;
   _cache: string[] | null = [];
   listener: any = undefined;
@@ -55,7 +56,7 @@ class Observer {
     var newQuery = _.merge(this._query, self._queryOptions);
     this._collection._getDocuments(newQuery, function (err: Error | null, result?: any[]) {
       if (self._options.init) {
-        self._options.init(result);
+        self._options.init(result || []);
       } else {
         merge(null, result, _.defaults({ comparatorId: comparator }, self._options));
       }
@@ -123,7 +124,7 @@ class Observer {
         index = length - 1;
       }
       if (this._options.changed) {
-        this._options.changed(null, doc.o, index); // have no access to asis / old document
+        this._options.changed(null as any, doc.o, index); // have no access to asis / old document
       }
     } else {
       this._onRemove(doc);

--- a/packages/viewdb_persistence_store_mongodb/src/store.ts
+++ b/packages/viewdb_persistence_store_mongodb/src/store.ts
@@ -1,15 +1,16 @@
 import Promise = require('bluebird');
 import Collection = require('./collection');
 import _ = require('lodash');
+import type { Db } from 'mongodb';
 
 class Store {
-  _mongodb: any;
+  _mongodb: Db;
   _oplogListeners: Record<string, any>;
   _collections: Record<string, any>;
   _oplogListener: any;
   _oplogEnabled: boolean;
 
-  constructor(mongodb: any, oplogEnabled?: boolean, oplogListener?: any) {
+  constructor(mongodb: Db, oplogEnabled?: boolean, oplogListener?: any) {
     this._mongodb = mongodb;
     this._oplogListeners = {};
     this._collections = {};

--- a/packages/viewdb_persistence_store_remote/src/client/collection.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/collection.ts
@@ -3,13 +3,14 @@ import _ = require('lodash');
 import Cursor = require('./cursor');
 import { EventEmitter } from 'events';
 import { v4 as uuid } from 'node-uuid';
+import { VdbClient } from '../types';
 
 class Collection extends EventEmitter {
   static Cursor: any = Cursor;
-  _client: any;
+  _client: VdbClient;
   _name: string;
 
-  constructor(client: any, collectionName: string) {
+  constructor(client: VdbClient, collectionName: string) {
     super();
     this._client = client;
     this._name = collectionName;

--- a/packages/viewdb_persistence_store_remote/src/client/observe.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/observe.ts
@@ -30,7 +30,7 @@ var buildParams = function (defaults: any, query: any, collection: any): any {
 };
 
 class Observer {
-  handles: any[] = [];
+  handles: string[] = [];
 
   constructor(collection: any, options: any, query: any) {
     var remoteHandle: any = null;

--- a/packages/viewdb_persistence_store_remote/src/client/rr_client.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/rr_client.ts
@@ -1,15 +1,16 @@
 import _ = require('lodash');
 import debug = require('debug');
+import { VdbSocket } from '../types';
 
 var warn = debug('viewdb:warn');
 
 class Client {
-  _socket: any;
+  _socket: VdbSocket | undefined;
   _requests: Record<number, { cb: Function; k: boolean }>;
   _requestId: number;
 
-  constructor(socket?: any) {
-    this._socket = null;
+  constructor(socket?: VdbSocket) {
+    this._socket = undefined;
     this._requests = {};
     this._requestId = 10;
     if (socket) {
@@ -17,7 +18,7 @@ class Client {
     }
   }
 
-  connect(socket: any): void {
+  connect(socket: VdbSocket): void {
     this._socket = socket;
     this._requests = {};
     this._requestId = 10;
@@ -46,7 +47,7 @@ class Client {
       p: payload
     };
     this._requests[req.i] = { cb: callback, k: persistent || false };
-    this._socket.emit('/vdb/request', req);
+    this._socket!.emit('/vdb/request', req);
     return req.i;
   }
 

--- a/packages/viewdb_persistence_store_remote/src/client/store.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/store.ts
@@ -1,11 +1,12 @@
 import Promise = require('bluebird');
 import Collection = require('./collection');
+import { VdbClient } from '../types';
 
 class Store {
   _collections: Record<string, Collection>;
-  _client: any;
+  _client: VdbClient;
 
-  constructor(client: any) {
+  constructor(client: VdbClient) {
     this._collections = {};
     this._client = client;
   }

--- a/packages/viewdb_persistence_store_remote/src/hybrid/observe.ts
+++ b/packages/viewdb_persistence_store_remote/src/hybrid/observe.ts
@@ -70,9 +70,9 @@ class HybridObserver {
   _remoteCache: any[];
   _removed: any[];
   _reconciledCache: any[];
-  _localHandle: any;
-  _remoteHandle: any;
-  _cacheUpdaterInterval: any;
+  _localHandle: { stop: () => void } | null;
+  _remoteHandle: { stop: () => void } | null;
+  _cacheUpdaterInterval: ReturnType<typeof setInterval> | null;
 
   constructor(localCursor: any, remoteCursor: any, collectionOptions: any, options: any) {
     var self = this;
@@ -83,6 +83,9 @@ class HybridObserver {
     this._options = options;
     this._cacheCallback = options.cacheCallback;
     this._getCache = options.getCache;
+    this._localHandle = null;
+    this._remoteHandle = null;
+    this._cacheUpdaterInterval = null;
 
     this._localCache = [];
     this._remoteCache = [];
@@ -121,8 +124,8 @@ class HybridObserver {
         (this as any)._remoteCache = null;
         (this as any)._reconciledCache = null;
         self._localHandle && self._localHandle.stop();
-        self._remoteHandle.stop();
-        clearInterval(self._cacheUpdaterInterval);
+        self._remoteHandle && self._remoteHandle.stop();
+        clearInterval(self._cacheUpdaterInterval!);
       }
     } as any;
   }

--- a/packages/viewdb_persistence_store_remote/src/hybrid/store.ts
+++ b/packages/viewdb_persistence_store_remote/src/hybrid/store.ts
@@ -2,7 +2,20 @@ import _ = require('lodash');
 import Promise = require('bluebird');
 import Collection = require('./collection');
 
-var defaultOptions = {
+interface HybridStoreOptions {
+  syncWrites: boolean;
+  cacheReads: boolean;
+  localFirst: boolean;
+  throwRemoteErr: boolean;
+  throttleObserveRefresh: number;
+  cacheLifeTime: number;
+  cacheQueries: boolean;
+  localOnlyCollections: Set<string>;
+  cacheCollectionName: string;
+  projectedDocumentsCollection: string;
+}
+
+var defaultOptions: HybridStoreOptions = {
   syncWrites: false, // if local writes should be sent over the wire to remote
   cacheReads: true, // when reading remote documents should they be stored in the local db
   localFirst: true, // when reading documents should we return the locally cached ones first and then the remote ones when they arrive
@@ -18,10 +31,10 @@ var defaultOptions = {
 class HybridStore {
   _local: any;
   _remote: any;
-  _options: any;
+  _options: HybridStoreOptions;
   _collections: Record<string, any>;
 
-  constructor(local: any, remote: any, options?: any) {
+  constructor(local: any, remote: any, options?: Partial<HybridStoreOptions>) {
     this._local = local;
     this._remote = remote;
     this._options = _.defaults(options || {}, defaultOptions);

--- a/packages/viewdb_persistence_store_remote/src/rest_client/rest_client.ts
+++ b/packages/viewdb_persistence_store_remote/src/rest_client/rest_client.ts
@@ -1,11 +1,12 @@
 import debug = require('debug');
 import _ = require('lodash');
+import { VdbClient } from '../types';
 
 var warn = debug('viewdb:warn');
 var merge = require('viewdb').merge;
 var axios: any = require('axios');
 
-class Client {
+class Client implements VdbClient {
   _pollInterval: number;
   _baseUri: string;
   _requestOptions: { headers: Record<string, string> };

--- a/packages/viewdb_persistence_store_remote/src/server/server.ts
+++ b/packages/viewdb_persistence_store_remote/src/server/server.ts
@@ -1,6 +1,7 @@
 import _ = require('lodash');
+import { VdbSocket } from '../types';
 
-function sendChange(socket: any, change: any, request: any): void {
+function sendChange(socket: VdbSocket, change: any, request: any): void {
   socket.emit('/vdb/response', {
     i: request.i,
     p: {
@@ -10,8 +11,8 @@ function sendChange(socket: any, change: any, request: any): void {
 }
 
 class ViewDbSocketServer {
-  constructor(viewdb: any, socket: any, queryDecorator?: any, globalLimit?: number, readPreference?: any) {
-    var _observers: Record<string, any> = {};
+  constructor(viewdb: any, socket: VdbSocket, queryDecorator?: any, globalLimit?: number, readPreference?: any) {
+    var _observers: Record<string, { i: number; handle: { stop: () => void } }> = {};
     var _queryDecorator: any;
     if (!queryDecorator) {
       _queryDecorator = function (_col: any, q: any, cb: any) {

--- a/packages/viewdb_persistence_store_remote/src/types.ts
+++ b/packages/viewdb_persistence_store_remote/src/types.ts
@@ -1,0 +1,11 @@
+/** Minimal socket interface — compatible with socket.io Socket */
+export interface VdbSocket {
+  emit(event: string, ...args: any[]): any;
+  on(event: string, callback: (...args: any[]) => void): any;
+}
+
+/** Client interface for request/response and subscriptions (rr_client, rest_client) */
+export interface VdbClient {
+  request(payload: Record<string, any>, callback?: (err: Error | null, result?: any) => void): void;
+  subscribe(payload: Record<string, any>, callback: (err: Error | null, result?: any) => void): void;
+}


### PR DESCRIPTION
﻿## Summary

- Eliminates ~49 `any` types across all 4 packages by introducing domain-specific interfaces and properly typing structural boundaries
- Adds `ObserveOptions`, `ObserveHandle`, `GetDocumentsFn`, `CollectionLike` interfaces to core viewdb types
- Creates local `VdbSocket`/`VdbClient` interfaces in remote store to avoid `@types/socket.io` dependency

## Changes by package

### Core viewdb (12 `any` eliminated)
- Added `ObserveOptions`, `ObserveHandle`, `GetDocumentsFn`, `CollectionLike` interfaces to `types.ts`
- Typed cursor, observe, and viewdb modules with new interfaces
- `inmemory/collection.ts` now `implements CollectionLike`

### MongoDB store (7 `any` eliminated)
- Imported `Db`, `Collection`, `FindCursor`, `Document` from `mongodb` driver
- Typed `_mongodb`, `_collection`, `_cursor` fields with proper driver types
- Used targeted `as any` casts only at `.apply()` forwarding call sites
- Imported `ObserveOptions` from viewdb for observe module

### IndexedDB store (14 `any` eliminated)
- Added `"lib": ["ES2018", "DOM"]` to tsconfig for DOM IndexedDB types
- Typed `_idb: IDBFactory`, `_db: IDBDatabase | null`
- Typed IDB request/transaction/cursor objects throughout collection.ts
- Used targeted `as any` only for `IDBTransaction.onsuccess` and dynamic method dispatch

### Remote store (16 `any` eliminated)
- Created `src/types.ts` with `VdbSocket`, `VdbClient` interfaces (avoids `@types/socket.io`)
- Typed socket/client fields across rr_client, client/store, client/collection, server
- Added `HybridStoreOptions` interface for hybrid store configuration
- `RestClient` now `implements VdbClient`

## Verification

- Full build: `npx turbo run build --force` - 4/4 packages clean, zero errors
- Full test suite: `npx turbo run test --force` - 163/163 tests pass
- No breaking API changes - all `module.exports` shapes preserved

## PR chain

This is PR 7 of 7 in the monorepo + TypeScript conversion chain:
1. #61 - Monorepo consolidation
2. #62 - TS shared infrastructure
3. #63 - Core viewdb to TypeScript
4. #64 - All stores to TypeScript
5. #65 - Cleanup and finalization
6. #66 - Tier 1 type improvements (~164 `any` eliminated)
7. **This PR** - Tier 2 type improvements (~49 `any` eliminated)

Remaining ~151 `any` are Tier 3 (structural: Observer factory, plugin architecture, kuery internals) - deferred to future work.
