### PR TITLE
refactor(deps): migrate from deprecated node-uuid to uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2780,15 +2780,6 @@
         "undici-types": "~7.19.0"
       }
     },
-    "node_modules/@types/node-uuid": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/node-uuid/-/node-uuid-0.0.32.tgz",
-      "integrity": "sha512-WLXK1lArYWwqwnpN72h7lUZzCoyZayxfHpA1WL/z82Bqa6nQZ7p518bDwH0aX/TJlnJJK/Jvgl+MEb1ipGdX/Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -6071,15 +6062,6 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true
     },
-    "node_modules/node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA==",
-      "deprecated": "Use uuid module instead",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -7456,11 +7438,11 @@
         "bluebird": "^3.7.2",
         "kuery": "^0.5.3",
         "lodash": "^4.17.21",
-        "node-uuid": "^1.4.3"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/bluebird": "3.5.42",
-        "@types/node-uuid": "0.0.32",
+        "@types/uuid": "9.0.8",
         "fake-indexeddb": "^2.0.2",
         "mocha": "^10.7.3",
         "should": "^4.1.0",
@@ -7525,15 +7507,15 @@
         "debug": "^2.2.0",
         "kuery": "^0.5.4",
         "lodash": "^4.17.21",
-        "node-uuid": "^1.4.3",
-        "slf": "^1.0.0"
+        "slf": "^1.0.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
         "@types/bluebird": "3.5.42",
         "@types/crypto-js": "4.2.2",
         "@types/debug": "4.1.13",
-        "@types/node-uuid": "0.0.32",
+        "@types/uuid": "9.0.8",
         "babel-jest": "^29.4.3",
         "jest": "^29.4.3",
         "nock": "^13.3.0",
@@ -9474,15 +9456,6 @@
       "dev": true,
       "requires": {
         "undici-types": "~7.19.0"
-      }
-    },
-    "@types/node-uuid": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/node-uuid/-/node-uuid-0.0.32.tgz",
-      "integrity": "sha512-WLXK1lArYWwqwnpN72h7lUZzCoyZayxfHpA1WL/z82Bqa6nQZ7p518bDwH0aX/TJlnJJK/Jvgl+MEb1ipGdX/Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -11876,11 +11849,6 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA=="
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12749,14 +12717,14 @@
       "version": "file:packages/viewdb_persistence_store_indexeddb",
       "requires": {
         "@types/bluebird": "3.5.42",
-        "@types/node-uuid": "0.0.32",
+        "@types/uuid": "9.0.8",
         "bluebird": "^3.7.2",
         "fake-indexeddb": "^2.0.2",
         "kuery": "^0.5.3",
         "lodash": "^4.17.21",
         "mocha": "^10.7.3",
-        "node-uuid": "^1.4.3",
         "should": "^4.1.0",
+        "uuid": "^9.0.0",
         "viewdb": "*"
       },
       "dependencies": {
@@ -12810,7 +12778,7 @@
         "@types/bluebird": "3.5.42",
         "@types/crypto-js": "4.2.2",
         "@types/debug": "4.1.13",
-        "@types/node-uuid": "0.0.32",
+        "@types/uuid": "9.0.8",
         "axios": "^1.7.7",
         "babel-jest": "^29.4.3",
         "bluebird": "^2.9.30",
@@ -12820,12 +12788,12 @@
         "kuery": "^0.5.4",
         "lodash": "^4.17.21",
         "nock": "^13.3.0",
-        "node-uuid": "^1.4.3",
         "prettier": "3.0.3",
         "prettier-config-surikaterna": "^1.0.1",
         "should": "^13.2.3",
         "slf": "^1.0.0",
         "socket.io-mock": "^1.2.3",
+        "uuid": "^9.0.0",
         "viewdb": "*"
       },
       "dependencies": {

--- a/packages/viewdb_persistence_store_indexeddb/package.json
+++ b/packages/viewdb_persistence_store_indexeddb/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/bluebird": "3.5.42",
-    "@types/node-uuid": "0.0.32",
+    "@types/uuid": "9.0.8",
     "fake-indexeddb": "^2.0.2",
     "mocha": "^10.7.3",
     "should": "^4.1.0",
@@ -37,6 +37,6 @@
     "bluebird": "^3.7.2",
     "kuery": "^0.5.3",
     "lodash": "^4.17.21",
-    "node-uuid": "^1.4.3"
+    "uuid": "^9.0.0"
   }
 }

--- a/packages/viewdb_persistence_store_indexeddb/src/collection.ts
+++ b/packages/viewdb_persistence_store_indexeddb/src/collection.ts
@@ -1,6 +1,6 @@
 import Promise = require('bluebird');
 import _ = require('lodash');
-import { v4 as uuid } from 'node-uuid';
+import { v4 as uuid } from 'uuid';
 import Kuery = require('kuery');
 import { EventEmitter } from 'events';
 

--- a/packages/viewdb_persistence_store_remote/package.json
+++ b/packages/viewdb_persistence_store_remote/package.json
@@ -32,7 +32,7 @@
     "@types/bluebird": "3.5.42",
     "@types/crypto-js": "4.2.2",
     "@types/debug": "4.1.13",
-    "@types/node-uuid": "0.0.32",
+    "@types/uuid": "9.0.8",
     "babel-jest": "^29.4.3",
     "jest": "^29.4.3",
     "nock": "^13.3.0",
@@ -49,7 +49,7 @@
     "debug": "^2.2.0",
     "kuery": "^0.5.4",
     "lodash": "^4.17.21",
-    "node-uuid": "^1.4.3",
+    "uuid": "^9.0.0",
     "slf": "^1.0.0"
   }
 }

--- a/packages/viewdb_persistence_store_remote/src/client/collection.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/collection.ts
@@ -2,7 +2,7 @@ import Promise = require('bluebird');
 import _ = require('lodash');
 import Cursor = require('./cursor');
 import { EventEmitter } from 'events';
-import { v4 as uuid } from 'node-uuid';
+import { v4 as uuid } from 'uuid';
 import { VdbClient } from '../types';
 
 class Collection extends EventEmitter {

--- a/packages/viewdb_persistence_store_remote/src/client/cursor.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/cursor.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'slf';
-import { v4 as uuid } from 'node-uuid';
+import { v4 as uuid } from 'uuid';
 import _ = require('lodash');
 import Observer = require('./observe');
 

--- a/packages/viewdb_persistence_store_remote/src/client/observe.ts
+++ b/packages/viewdb_persistence_store_remote/src/client/observe.ts
@@ -1,6 +1,6 @@
 import _ = require('lodash');
 import { Logger } from 'slf';
-import { v4 as uuid } from 'node-uuid';
+import { v4 as uuid } from 'uuid';
 
 var LOG = Logger.getLogger('lx:viewdb-persistence-store-remote');
 


### PR DESCRIPTION
﻿## Summary

- Migrate from deprecated `node-uuid` (last published 2015) to `uuid@^9.0.0`
- Aligns indexeddb and remote stores with core viewdb, which already uses `uuid`
- API is identical — only `v4()` is used across all packages

## Changes

| File | Change |
|------|--------|
| `packages/viewdb_persistence_store_indexeddb/src/collection.ts` | `'node-uuid'` -> `'uuid'` |
| `packages/viewdb_persistence_store_remote/src/client/collection.ts` | `'node-uuid'` -> `'uuid'` |
| `packages/viewdb_persistence_store_remote/src/client/cursor.ts` | `'node-uuid'` -> `'uuid'` |
| `packages/viewdb_persistence_store_remote/src/client/observe.ts` | `'node-uuid'` -> `'uuid'` |
| `packages/viewdb_persistence_store_indexeddb/package.json` | `node-uuid` -> `uuid`, `@types/node-uuid` -> `@types/uuid` |
| `packages/viewdb_persistence_store_remote/package.json` | `node-uuid` -> `uuid`, `@types/node-uuid` -> `@types/uuid` |

## Verification

- All 163 tests pass (53 viewdb + 23 indexeddb + 30 mongodb + 57 remote)
- All 4 packages build cleanly
