### PR TITLE
fix(exports): remove __esModule flag from CJS output of remote and lokijs stores

### DIFF
--- a/.changeset/fix-cjs-exports.md
+++ b/.changeset/fix-cjs-exports.md
@@ -1,0 +1,6 @@
+---
+'viewdb_persistence_store_remote': patch
+'viewdb_persistence_store_lokijs': patch
+---
+
+Fix CJS exports to use module.exports instead of named exports, preventing \_\_esModule flag from appearing in compiled output

--- a/packages/viewdb_persistence_store_lokijs/src/index.ts
+++ b/packages/viewdb_persistence_store_lokijs/src/index.ts
@@ -3,4 +3,4 @@ import Collection = require('./collection');
 import LokiPartitioningAdapter = require('./adapter/LokiPartitioningAdapter');
 import LokiCordovaFSAdapter = require('./cordova/LokiCordovaFSAdapter');
 
-export { Store, Collection, LokiPartitioningAdapter, LokiCordovaFSAdapter };
+export = { Store, Collection, LokiPartitioningAdapter, LokiCordovaFSAdapter };

--- a/packages/viewdb_persistence_store_remote/src/index.ts
+++ b/packages/viewdb_persistence_store_remote/src/index.ts
@@ -4,4 +4,4 @@ import Hybrid = require('./hybrid/store');
 import RestClient = require('./rest_client/rest_client');
 import SocketClient = require('./client/rr_client');
 
-export { Server, Client, Hybrid, RestClient, SocketClient };
+export = { Server, Client, Hybrid, RestClient, SocketClient };


### PR DESCRIPTION
﻿## Summary

- Fixes a **breaking change** introduced during the TypeScript conversion (PR #64 for remote, PR #70 for lokijs)
- Both stores used `export { ... }` which compiles to `Object.defineProperty(exports, "__esModule", { value: true })` — this flag was **not present** in the original pre-TS JavaScript
- The `__esModule` flag can break consumers using ESM default import interop

## Fix

Changed `export { ... }` to `export = { ... }` in both packages, which compiles to `module.exports = { ... }` (matching the original CJS behavior, no `__esModule` flag).

## Files changed

| File | Change |
|------|--------|
| `packages/viewdb_persistence_store_remote/src/index.ts` | `export { ... }` to `export = { ... }` |
| `packages/viewdb_persistence_store_lokijs/src/index.ts` | `export { ... }` to `export = { ... }` |
| `.changeset/fix-cjs-exports.md` | Patch bump for both packages |

## Verification

- Build succeeds (5/5 packages)
- Compiled `dist/index.js` uses `module.exports =` without `__esModule` for both packages
- All 190 tests pass across all 5 packages
- CJS `require()` consumers work identically (destructuring and property access)
- ESM default import interop restored (no `__esModule` to confuse bundlers)

## Checklist

- [x] Correctness validated; no avoidable unsafe patterns
- [x] Defaults followed; no exception needed
- [x] Files remain cohesive and under 400 lines
- [x] Functions under 50 lines, nesting under 3 levels
- [x] Tests added/updated proportional to risk (190 existing tests cover this)
- [x] Lint and tests pass
