### PR TITLE
fix(remote): flaky timing assertion in hybrid store cache test

### DIFF
--- a/packages/viewdb_persistence_store_remote/__tests__/hybrid/store.js
+++ b/packages/viewdb_persistence_store_remote/__tests__/hybrid/store.js
@@ -57,7 +57,7 @@ describe('Store', function () {
                           hcursor.collection('alfa')._getCachedData({ id: 'abc' }, undefined, undefined, undefined, { id: 1 }, function (_err2, projectedData) {
                             data.length.should.equal(1);
                             projectedData.length.should.equal(1);
-                            projectedData[0]._insertedAt.should.be.below(data[0]._insertedAt);
+                            projectedData[0]._insertedAt.should.be.belowOrEqual(data[0]._insertedAt);
                             resolve();
                           });
                         });


### PR DESCRIPTION
## Summary

- Fixes flaky test `should cache projected data separate` in `viewdb_persistence_store_remote` hybrid store tests
- The test asserted strict `<` on `_insertedAt` timestamps, but both cache operations can complete within the same millisecond, causing identical timestamps and assertion failure
- Changed `should.be.below` to `should.be.belowOrEqual` to use `<=`, preserving the test intent (projected data cached first or simultaneously) while being timing-safe

## Context

Reported by @kennyek during PR #76 review. This is a pre-existing flaky test exposed by the Vitest migration, not caused by #76 changes.

Error was:
```
AssertionError: expected 1776432872310 to be below 1776432872310
```

## Changes

- `packages/viewdb_persistence_store_remote/__tests__/hybrid/store.js` line 60: `.below(` to `.belowOrEqual(`

## Verification

All 57 remote store tests pass (`npx vitest run` in `packages/viewdb_persistence_store_remote`).