### PR TITLE
PR #74 review followups: merger perf, observer refactor, writable types

### DIFF
--- a/.changeset/pr74-review-followups.md
+++ b/.changeset/pr74-review-followups.md
@@ -1,0 +1,5 @@
+---
+'viewdb': minor
+---
+
+Optimize merger with Map-based index tracking, extract observer listener into private method, and add WritableCollectionLike interface with Promise-based write method signatures.

--- a/packages/viewdb/src/merger.ts
+++ b/packages/viewdb/src/merger.ts
@@ -11,18 +11,36 @@ function contains<T>(list: T[], element: T, comparator: (a: T, b: T) => boolean)
   return undefined;
 }
 
+function removeAt<T>(list: T[], indexMap: Map<T, number>, index: number): void {
+  const removed = list[index];
+  list.splice(index, 1);
+  indexMap.delete(removed);
+  for (let i = index; i < list.length; i++) {
+    indexMap.set(list[i], i);
+  }
+}
+
+function insertAt<T>(list: T[], indexMap: Map<T, number>, index: number, element: T): void {
+  list.splice(index, 0, element);
+  for (let i = index; i < list.length; i++) {
+    indexMap.set(list[i], i);
+  }
+}
+
 function merge<T>(asis: T[] | null, tobe: T[], options?: MergeOptions<T>): T[] {
   options = options || {};
   const comparator = options.comparator || _.isEqual;
   const comparatorId = options.comparatorId || comparator;
   const list = _.slice(asis as T[]);
+  const indexMap = new Map<T, number>();
+  list.forEach((e, i) => indexMap.set(e, i));
 
   // check removed
   _.forEach(asis, function (e: T) {
     const found = contains(tobe, e, comparatorId);
     if (found === undefined) {
-      const index = list.indexOf(e);
-      list.splice(index, 1);
+      const index = indexMap.get(e)!;
+      removeAt(list, indexMap, index);
       if (options!.removed) {
         options!.removed(e, index);
       }
@@ -35,24 +53,26 @@ function merge<T>(asis: T[] | null, tobe: T[], options?: MergeOptions<T>): T[] {
     const found = contains(list, e, comparatorId);
     // added
     if (found === undefined) {
-      list.splice(indexInNew, 0, e);
+      insertAt(list, indexMap, indexInNew, e);
       if (options!.added) {
         options!.added(e, indexInNew);
       }
     } else {
       // existed before
-      const indexInOld = list.indexOf(found);
+      const indexInOld = indexMap.get(found)!;
       if (indexInOld !== indexInNew) {
         // remove
-        list.splice(indexInOld, 1);
+        removeAt(list, indexMap, indexInOld);
         // add
-        list.splice(indexInNew, 0, e);
+        insertAt(list, indexMap, indexInNew, e);
         if (options!.moved) {
           options!.moved(e, indexInOld, indexInNew);
         }
       }
       if (!comparator(found, e)) {
+        indexMap.delete(found);
         list[indexInNew] = e;
+        indexMap.set(e, indexInNew);
         if (options!.changed) {
           options!.changed(found, e, indexInNew);
         }

--- a/packages/viewdb/src/observe.ts
+++ b/packages/viewdb/src/observe.ts
@@ -8,6 +8,7 @@ class Observer {
   _options: ObserveOptions;
   _collection: CollectionLike;
   _cache: VDocument[] | null;
+  private _boundListener: () => void;
 
   constructor(query: QueryObject, queryOptions: QueryObject, collection: CollectionLike, options: ObserveOptions) {
     this._query = query;
@@ -16,21 +17,23 @@ class Observer {
     this._collection = collection;
     this._cache = [];
 
-    const self = this;
-    const listener = function () {
-      self.refresh();
-    };
-    collection.on('change', listener);
+    this._boundListener = this._onCollectionChange.bind(this);
+    collection.on('change', this._boundListener);
     this.refresh(true);
 
     // The constructor returns a plain object, not `this`.
     // This matches the original JS behavior.
+    const self = this;
     return {
       stop: function () {
         self._cache = null;
-        collection.removeListener('change', listener);
+        collection.removeListener('change', self._boundListener);
       }
     } as any;
+  }
+
+  private _onCollectionChange(): void {
+    this.refresh();
   }
 
   refresh(initial?: boolean): void {

--- a/packages/viewdb/src/types.ts
+++ b/packages/viewdb/src/types.ts
@@ -61,3 +61,16 @@ export interface CollectionLike {
   on(event: string, listener: (...args: any[]) => void): any;
   removeListener(event: string, listener: (...args: any[]) => void): any;
 }
+
+/**
+ * Extended collection interface for stores that support write operations.
+ * Methods use Promise-based signatures as the migration target.
+ * All methods are optional — stores implement them as they migrate from callbacks to Promises.
+ */
+export interface WritableCollectionLike extends CollectionLike {
+  insert?(doc: VDocument | VDocument[], options?: Record<string, any>): Promise<VDocument[]>;
+  save?(doc: VDocument | VDocument[], options?: Record<string, any>): Promise<VDocument[]>;
+  remove?(query: Record<string, any>, options?: Record<string, any>): Promise<void>;
+  count?(): Promise<number>;
+  drop?(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

Addresses three follow-up items from PR #74 review by @kennyek:

- **#79** `perf(merger)`: Replace O(n) `indexOf` calls with Map-based O(1) index tracking in the merge removal and move paths
- **#80** `refactor(observe)`: Extract inline change listener closure from Observer constructor into private `_onCollectionChange` method
- **#81** `refactor(types)`: Add `WritableCollectionLike` interface extending `CollectionLike` with optional Promise-based `insert`/`save`/`remove`/`count`/`drop` signatures as a migration target

## Changes

| File | Lines | What |
|------|-------|------|
| `packages/viewdb/src/merger.ts` | +26/-6 | Added `indexMap`, `removeAt`, `insertAt` helpers; replaced `indexOf` with Map lookups |
| `packages/viewdb/src/observe.ts` | +9/-6 | Added `_boundListener` field + `_onCollectionChange()` method; removed inline closure |
| `packages/viewdb/src/types.ts` | +13 | Added `WritableCollectionLike` interface (all methods optional) |

## Verification

All 53 tests pass in `packages/viewdb` (`npx vitest run`). TypeScript compiles clean (`npx tsc --noEmit`).

Closes #79, closes #80, closes #81