### PR TITLE
Upgrade kuery to 2.0.0 in mongodb store — 6-65x faster observer matching

### DIFF
--- a/.changeset/upgrade-kuery-mongodb.md
+++ b/.changeset/upgrade-kuery-mongodb.md
@@ -1,0 +1,5 @@
+---
+'viewdb_persistence_store_mongodb': minor
+---
+
+Upgrade kuery to 2.0.0 and use .test(doc) for single-document matching in observer hot path, eliminating unnecessary array allocations per oplog event

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ dist/
 
 # TypeScript build output
 *.tsbuildinfo
+
+# Worktrees
+trees/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4312,7 +4312,7 @@
       "license": "MIT",
       "dependencies": {
         "bluebird": "^2.9.30",
-        "kuery": "^0.5.5",
+        "kuery": "^2.0.0",
         "lodash": "^4.18.0",
         "mongodb": "^6.12.0",
         "slf": "^2.0.3"
@@ -4378,12 +4378,10 @@
       }
     },
     "packages/viewdb_persistence_store_mongodb/node_modules/kuery": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/kuery/-/kuery-0.5.5.tgz",
-      "integrity": "sha512-osS2dsnFsgzIr3OzoD7Kh+6+JJBHWiEqMLd9JYjykg8aLXB4ZhLe9WMXv53tZtc15yb3odoJY4rRc+0NUoXPeA==",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuery/-/kuery-2.0.0.tgz",
+      "integrity": "sha512-eDzweK6jkgz0SD7n3vnL9jUJyUykY9TJQtXV8xAk2vrxc4pHas9+ZccL2XSNwDcibc9bsqcCm7H6Li68qw/lmQ==",
+      "license": "ISC"
     },
     "packages/viewdb_persistence_store_mongodb/node_modules/mongodb-memory-server": {
       "version": "10.4.3",
@@ -7173,7 +7171,7 @@
         "@types/bluebird": "3.5.42",
         "bluebird": "^2.9.30",
         "jshint": "^2.13.6",
-        "kuery": "^0.5.5",
+        "kuery": "^2.0.0",
         "lodash": "^4.18.0",
         "mongodb": "^6.12.0",
         "mongodb-memory-server": "^10.0.0",
@@ -7215,12 +7213,9 @@
           }
         },
         "kuery": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/kuery/-/kuery-0.5.5.tgz",
-          "integrity": "sha512-osS2dsnFsgzIr3OzoD7Kh+6+JJBHWiEqMLd9JYjykg8aLXB4ZhLe9WMXv53tZtc15yb3odoJY4rRc+0NUoXPeA==",
-          "requires": {
-            "lodash": "^4.17.21"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/kuery/-/kuery-2.0.0.tgz",
+          "integrity": "sha512-eDzweK6jkgz0SD7n3vnL9jUJyUykY9TJQtXV8xAk2vrxc4pHas9+ZccL2XSNwDcibc9bsqcCm7H6Li68qw/lmQ=="
         },
         "mongodb-memory-server": {
           "version": "10.4.3",

--- a/packages/shared-types/kuery/index.d.ts
+++ b/packages/shared-types/kuery/index.d.ts
@@ -1,10 +1,13 @@
 declare module 'kuery' {
   class Kuery {
     constructor(query: any);
-    find(collection: any[]): any[];
-    limit(amount: number): void;
-    skip(amount: number): void;
-    sort(sortObject: Record<string, 1 | -1>): void;
+    /** Test a single document against the query. */
+    test(doc: any): boolean;
+    /** Find all matching documents with optional sort/skip/limit. */
+    find(collection: readonly any[]): readonly any[];
+    limit(amount: number): this;
+    skip(amount: number): this;
+    sort(sortObject: Record<string, 1 | -1>): this;
   }
 
   export = Kuery;

--- a/packages/viewdb_persistence_store_mongodb/package.json
+++ b/packages/viewdb_persistence_store_mongodb/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/surikaterna/viewdb_persistence_store_mongodb#readme",
   "dependencies": {
     "bluebird": "^2.9.30",
-    "kuery": "^0.5.5",
+    "kuery": "^2.0.0",
     "lodash": "^4.18.0",
     "mongodb": "^6.12.0",
     "slf": "^2.0.3"

--- a/packages/viewdb_persistence_store_mongodb/src/observe.ts
+++ b/packages/viewdb_persistence_store_mongodb/src/observe.ts
@@ -93,14 +93,13 @@ class Observer {
     }
   }
 
-  _checkKuery(coll: any[]): boolean {
-    var res = this._kuery.find(coll);
-    return res && res.length > 0;
+  _checkKuery(doc: any): boolean {
+    return this._kuery.test(doc);
   }
 
   _onInsert(doc: any): void {
     var index = this._cacheIndex!.get(doc.o._id);
-    var match = this._checkKuery([doc.o]);
+    var match = this._checkKuery(doc.o);
     if (match) {
       if (index !== undefined) {
         // already in cache - user has been notified by loadInitial method
@@ -122,7 +121,7 @@ class Observer {
   }
 
   _onUpdate(doc: any): void {
-    var match = this._checkKuery([doc.o]);
+    var match = this._checkKuery(doc.o);
     if (match) {
       var index = this._cacheIndex!.get(doc.o._id);
       if (index !== undefined) {


### PR DESCRIPTION
## Summary

- Upgrades `kuery` from `^0.5.5` to `^2.0.0` in `viewdb_persistence_store_mongodb`
- Replaces `_checkKuery([doc])` → `_checkKuery(doc)` using the new `.test(doc)` API
- Eliminates per-oplog-event array allocation that was pure overhead

## Motivation

`_checkKuery` is called **once per oplog event per active observer** — the absolute hot path for real-time reactivity. The old implementation wrapped every document in an array, fed it through lodash's `_.filter()`, allocated a result array, then checked `.length > 0`. All of that just to get a boolean.

kuery 2.0.0 (released 2026-05-22) is a zero-dependency TypeScript rewrite that exposes `Kuery.test(doc)` — a direct boolean predicate with no intermediate allocations.

## Benchmark Results (production pattern: one observer, one query, repeated calls)

```
--- simple eq: {"status":"active"} ---
  252.6 ns/op    1.0x  CURRENT: old.find([doc]).length > 0
   45.0 ns/op    5.6x  UPGRADE-A: new.find([doc]).length > 0
    4.3 ns/op   58.5x  UPGRADE-B: new.test(doc)           ← chosen approach
    3.9 ns/op   65.2x  UPGRADE-C: filter(doc)

--- $regex: {"name":{"$regex":"^test"}} ---
  224.9 ns/op    1.0x  CURRENT: old.find([doc]).length > 0
   66.9 ns/op    3.4x  UPGRADE-A: new.find([doc]).length > 0
   37.2 ns/op    6.1x  UPGRADE-B: new.test(doc)           ← chosen approach
   36.1 ns/op    6.2x  UPGRADE-C: filter(doc)

--- $and compound: {"$and":[{"status":"active"},{"age":{"$gte":18}}]} ---
  488.0 ns/op    1.0x  CURRENT: old.find([doc]).length > 0
   98.8 ns/op    4.9x  UPGRADE-A: new.find([doc]).length > 0
   58.3 ns/op    8.4x  UPGRADE-B: new.test(doc)           ← chosen approach
   64.2 ns/op    7.6x  UPGRADE-C: filter(doc)

--- dot path: {"address.city":"Stockholm"} ---
 2478.4 ns/op    1.0x  CURRENT: old.find([doc]).length > 0
   98.9 ns/op   25.1x  UPGRADE-A: new.find([doc]).length > 0
   71.8 ns/op   34.5x  UPGRADE-B: new.test(doc)           ← chosen approach
   65.4 ns/op   37.9x  UPGRADE-C: filter(doc)
```

**TL;DR: 6–65x faster per oplog event**, depending on query complexity. Dot-path queries see the largest gain (old lodash-based path resolution was extremely slow).

## Why `.test(doc)` over `compileFilter()`?

Both are equivalent in production (V8 inlines the method dispatch). `.test()` was chosen because:
- The `Kuery` instance is already constructed for `loadInitial`'s `.find()` call
- One fewer variable to manage
- Class instances give V8 stable hidden-class optimization

## Changes

| File | Change |
|------|--------|
| `packages/viewdb_persistence_store_mongodb/package.json` | `kuery` dep `^0.5.5` → `^2.0.0` |
| `packages/viewdb_persistence_store_mongodb/src/observe.ts` | `_checkKuery` uses `.test(doc)`; call sites pass `doc.o` directly |
| `packages/shared-types/kuery/index.d.ts` | Added `test()` method to type declarations |
| `.gitignore` | Added `trees/` for worktree convention |

## Risk

- **Low**: kuery 2.0.0's `.find()` is backward-compatible (same semantics), and `.test()` is a strict subset
- **Scoped**: Only `viewdb_persistence_store_mongodb` is touched; other packages keep their existing kuery versions
- **Tested**: All 31 existing tests pass
